### PR TITLE
Fix handling of dynamic class instantiation from string

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -33,6 +33,7 @@ use Psalm\Internal\GzipSerializer;
 use Psalm\Internal\IncludeCollector;
 use Psalm\Internal\Lz4Serializer;
 use Psalm\Internal\Provider\AddRemoveTaints\HtmlFunctionTainter;
+use Psalm\Internal\StringInterpreter\ClassStringInterpreter;
 use Psalm\Internal\Scanner\FileScanner;
 use Psalm\Issue\ArgumentIssue;
 use Psalm\Issue\ClassConstantIssue;
@@ -1668,6 +1669,10 @@ final class Config
         new HtmlFunctionTainter();
 
         $socket->registerHooksFromClass(HtmlFunctionTainter::class);
+
+        new ClassStringInterpreter();
+
+        $socket->registerHooksFromClass(ClassStringInterpreter::class);
     }
 
     private function loadPlugin(ProjectAnalyzer $projectAnalyzer, string $pluginClassName): PluginInterface

--- a/src/Psalm/Internal/PreloaderList.php
+++ b/src/Psalm/Internal/PreloaderList.php
@@ -851,6 +851,7 @@ final class PreloaderList {
         \Psalm\Internal\Preloader::class,
         \Psalm\Internal\PreloaderList::class,
         \Psalm\Internal\Provider\AddRemoveTaints\HtmlFunctionTainter::class,
+        \Psalm\Internal\StringInterpreter\ClassStringInterpreter::class,
         \Psalm\Internal\Provider\ClassLikeStorageCacheProvider::class,
         \Psalm\Internal\Provider\ClassLikeStorageProvider::class,
         \Psalm\Internal\Provider\DynamicFunctionStorageProvider::class,

--- a/src/Psalm/Internal/StringInterpreter/ClassStringInterpreter.php
+++ b/src/Psalm/Internal/StringInterpreter/ClassStringInterpreter.php
@@ -4,7 +4,15 @@ declare(strict_types=1);
 
 namespace Psalm\Internal\StringInterpreter;
 
+use AssertionError;
+use Exception;
+use InvalidArgumentException;
+use LogicException;
 use Override;
+use Psalm\Exception\CodeException;
+use Psalm\Exception\TypeParseTreeException;
+use Psalm\Exception\UnpopulatedClasslikeException;
+use Psalm\Exception\UnresolvableConstantException;
 use Psalm\Internal\Codebase\Reflection;
 use Psalm\Plugin\EventHandler\Event\StringInterpreterEvent;
 use Psalm\Plugin\EventHandler\StringInterpreterInterface;
@@ -12,6 +20,7 @@ use Psalm\Type\Atomic\TLiteralClassString;
 use Psalm\Type\Atomic\TLiteralString;
 use ReflectionClass;
 use ReflectionException;
+use UnexpectedValueException;
 
 use function class_exists;
 use function enum_exists;
@@ -25,6 +34,17 @@ use function trait_exists;
  */
 final class ClassStringInterpreter implements StringInterpreterInterface
 {
+    /**
+     * @throws AssertionError
+     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws LogicException
+     * @throws CodeException
+     * @throws TypeParseTreeException
+     * @throws UnpopulatedClasslikeException
+     * @throws UnresolvableConstantException
+     * @throws UnexpectedValueException
+     */
     #[Override]
     public static function getTypeFromValue(StringInterpreterEvent $event): ?TLiteralString
     {

--- a/src/Psalm/Internal/StringInterpreter/ClassStringInterpreter.php
+++ b/src/Psalm/Internal/StringInterpreter/ClassStringInterpreter.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\StringInterpreter;
+
+use Override;
+use Psalm\Plugin\EventHandler\Event\StringInterpreterEvent;
+use Psalm\Plugin\EventHandler\StringInterpreterInterface;
+use Psalm\Internal\Codebase\Reflection;
+use Psalm\Type\Atomic\TLiteralClassString;
+use Psalm\Type\Atomic\TLiteralString;
+
+/**
+ * @internal
+ */
+final class ClassStringInterpreter implements StringInterpreterInterface
+{
+    #[Override]
+    public static function getTypeFromValue(StringInterpreterEvent $event): ?TLiteralString
+    {
+        $value = $event->getValue();
+        if ($value === '') {
+            return null;
+        }
+
+        $value = ltrim($value, '\\');
+        $codebase = $event->getCodebase();
+        $value_lc = strtolower($value);
+
+        if ($codebase->classlikes->doesClassLikeExist($value_lc)) {
+            if (!$codebase->classlike_storage_provider->has($value)) {
+                $reflection = new Reflection($codebase->classlike_storage_provider, $codebase);
+                try {
+                    $reflection->registerClass(new \ReflectionClass($value));
+                } catch (\ReflectionException) {
+                    return null;
+                }
+            }
+
+            return new TLiteralClassString($value);
+        }
+
+        return null;
+    }
+}

--- a/tests/DynamicClassInstantiationUsingAVariable.php
+++ b/tests/DynamicClassInstantiationUsingAVariable.php
@@ -55,6 +55,8 @@ final class DynamicClassInstantiationUsingAVariable extends TestCase
             ',
         );
 
+        $this->project_analyzer->getCodebase()->config->initializePlugins($this->project_analyzer);
+
         $context = new Context();
 
         $this->analyzeFile('somefile.php', $context);


### PR DESCRIPTION
## Summary
- add `ClassStringInterpreter` that loads class storage via reflection when class-like strings are encountered
- register interpreter plugin when initializing config
- remove stub for built-in `AssertionError`
- ensure plugin is initialised in new test

## Testing
- `vendor/bin/phpunit tests/DynamicClassInstantiationUsingAVariable.php`

------
https://chatgpt.com/codex/tasks/task_e_685bb97c0cf48328bea2cf6fc01d44e1